### PR TITLE
Improvement: detailed circuit broken errors

### DIFF
--- a/lib/Brakes.js
+++ b/lib/Brakes.js
@@ -49,7 +49,7 @@ class Brakes extends EventEmitter {
       if (this._fallback) {
         return this._fallback.apply(this, arguments);
       }
-      return Promise.reject(new CircuitBrokenError(this._stats, this._opts));
+      return Promise.reject(new CircuitBrokenError(this._stats._totals, this._opts.threshold));
     }
 
     const startTime = new Date().getTime();

--- a/lib/Brakes.js
+++ b/lib/Brakes.js
@@ -5,6 +5,7 @@ const Promise = require('bluebird');
 const Stats = require('./Stats');
 const hasCallback = require('./utils').hasCallback;
 const TimeOutError = require('./TimeOutError');
+const CircuitBrokenError = require('../lib/CircuitBrokenError');
 const consts = require('./consts');
 
 const defaultOptions = {
@@ -48,7 +49,7 @@ class Brakes extends EventEmitter {
       if (this._fallback) {
         return this._fallback.apply(this, arguments);
       }
-      return Promise.reject(consts.CIRCUIT_BROKEN);
+      return Promise.reject(new CircuitBrokenError(this._stats, this._opts));
     }
 
     const startTime = new Date().getTime();

--- a/lib/CircuitBrokenError.js
+++ b/lib/CircuitBrokenError.js
@@ -4,11 +4,11 @@ const consts = require('./consts');
 
 class CircuitBrokenError extends Error {
 
-  constructor(stats, opts) {
+  constructor(totals, threshold) {
     super();
 
-    this.message = `${consts.CIRCUIT_BROKEN} - The percentage of failed requests (${Math.floor((stats.failed / stats.total) * 100)}%) is greater than the threshold specified (${opts.threshold * 100}%)`;
-    this.stats = stats;
+    this.message = `${consts.CIRCUIT_BROKEN} - The percentage of failed requests (${Math.floor((totals.failed / totals.total) * 100)}%) is greater than the threshold specified (${threshold * 100}%)`;
+    this.totals = totals;
   }
 }
 

--- a/lib/CircuitBrokenError.js
+++ b/lib/CircuitBrokenError.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const consts = require('./consts');
+
+class CircuitBrokenError extends Error {
+
+  constructor(stats, opts) {
+    super();
+
+    this.message = `${consts.CIRCUIT_BROKEN} - The percentage of failed requests (${Math.floor((stats.failed / stats.total) * 100)}%) is greater than the threshold specified (${opts.threshold * 100}%)`;
+    this.stats = stats;
+  }
+}
+
+module.exports = CircuitBrokenError;

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -24,6 +24,7 @@ class Stats extends EventEmitter {
     }
     this._activeBucket = this._buckets[this._activePosition];
     this._startBucketSpinning();
+    this._totals = this._generateStats(this._buckets);
   }
 
   reset() {
@@ -101,7 +102,7 @@ class Stats extends EventEmitter {
     this._totals.requestTimes.sort((a, b) => a - b);
     this._opts.percentiles.forEach((p) => {
       this._totals.percentiles[p] =
-      this._calculatePercentile(p, this._totals.requestTimes) || 0;
+        this._calculatePercentile(p, this._totals.requestTimes) || 0;
     });
 
     // remove large totals Arrays

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   TIMEOUT: 'Request Timed out',
-  CIRCUIT_BROKEN: 'Circuit has been broken.',
+  CIRCUIT_BROKEN: 'Circuit has been broken',
   INVALID_BUCKET_PROP: 'Attempt to access nonexistent bucket property',
   NO_FUNCTION: 'Brakes must be passed a function'
 };

--- a/tests/Brakes.spec.js
+++ b/tests/Brakes.spec.js
@@ -136,7 +136,7 @@ describe('Brakes Class', () => {
     const brake = new Brakes(nopr);
     brake._closed = true;
     return brake.exec(null, 'err').then(null, err => {
-      expect(err).to.equal(consts.CIRCUIT_BROKEN);
+      expect(err).to.be.instanceof(CircuitBrokenError);
     });
   });
   it('Should call fallback if circuit is broken', () => {

--- a/tests/Brakes.spec.js
+++ b/tests/Brakes.spec.js
@@ -6,6 +6,7 @@ const consts = require('../lib/consts');
 const EventEmitter = require('events').EventEmitter;
 const sinon = require('sinon');
 const TimeOutError = require('../lib/TimeOutError');
+const CircuitBrokenError = require('../lib/CircuitBrokenError');
 
 const defaultOptions = {
   bucketSpan: 1000,

--- a/tests/Brakes.spec.js
+++ b/tests/Brakes.spec.js
@@ -2,7 +2,6 @@
 
 const Brakes = require('../lib/Brakes');
 const expect = require('chai').expect;
-const consts = require('../lib/consts');
 const EventEmitter = require('events').EventEmitter;
 const sinon = require('sinon');
 const TimeOutError = require('../lib/TimeOutError');

--- a/tests/CircuitBrokenError.spec.js
+++ b/tests/CircuitBrokenError.spec.js
@@ -23,8 +23,14 @@ describe('CircuitBrokenError', () => {
       successful: 40
     };
     const mockThreshold = 0.5;
-    expect(new CircuitBrokenError(mockTotals, mockThreshold)).to.have.a.property('message').that.is.a('string');
-    expect(new CircuitBrokenError(mockTotals, mockThreshold)).to.have.a.property('totals').that.is.an('object');
+    const error = new CircuitBrokenError(mockTotals, mockThreshold);
+    expect(error).to.have.a.property('message').that.is.a('string');
+    expect(error).to.have.a.property('totals').that.is.an('object');
+    expect(error).to.have.a.property('totals').that.is.an('object');
+    expect(error.totals).to.have.a.property('failed');
+    expect(error.totals).to.have.a.property('timedOut');
+    expect(error.totals).to.have.a.property('total');
+    expect(error.totals).to.have.a.property('successful');
   });
   it('Should have expected error string with calculated failure percentage', () => {
     const mockTotals = {

--- a/tests/CircuitBrokenError.spec.js
+++ b/tests/CircuitBrokenError.spec.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const CircuitBrokenError = require('../lib/CircuitBrokenError');
+const consts = require('../lib/consts');
+const expect = require('chai').expect;
+
+describe('CircuitBrokenError', () => {
+  it('Should be an instance of error', () => {
+    const mockTotals = {
+      failed: 60,
+      timedOut: 0,
+      total: 100,
+      successful: 40
+    };
+    const mockThreshold = 0.5;
+    expect(new CircuitBrokenError(mockTotals, mockThreshold)).to.be.instanceof(Error);
+  });
+  it('Should contain expected properties', () => {
+    const mockTotals = {
+      failed: 60,
+      timedOut: 0,
+      total: 100,
+      successful: 40
+    };
+    const mockThreshold = 0.5;
+    expect(new CircuitBrokenError(mockTotals, mockThreshold)).to.have.a.property('message').that.is.a('string');
+    expect(new CircuitBrokenError(mockTotals, mockThreshold)).to.have.a.property('totals').that.is.an('object');
+  });
+  it('Should have expected error string with calculated failure percentage', () => {
+    const mockTotals = {
+      failed: 60,
+      timedOut: 0,
+      total: 100,
+      successful: 40
+    };
+    const mockThreshold = 0.5;
+    expect(new CircuitBrokenError(mockTotals, mockThreshold)).to.have.a.property('message').that.equals(`${consts.CIRCUIT_BROKEN} - The percentage of failed requests (60%) is greater than the threshold specified (50%)`);
+  });
+
+});

--- a/tests/CircuitBrokenError.spec.js
+++ b/tests/CircuitBrokenError.spec.js
@@ -25,7 +25,6 @@ describe('CircuitBrokenError', () => {
     const mockThreshold = 0.5;
     const error = new CircuitBrokenError(mockTotals, mockThreshold);
     expect(error).to.have.a.property('message').that.is.a('string');
-    expect(error).to.have.a.property('totals').that.is.an('object');
     expect(error).to.have.a.property('totals').that.is.an('object').that.deep.equals(mockTotals);
   });
   it('Should have expected error string with calculated failure percentage', () => {

--- a/tests/CircuitBrokenError.spec.js
+++ b/tests/CircuitBrokenError.spec.js
@@ -26,11 +26,7 @@ describe('CircuitBrokenError', () => {
     const error = new CircuitBrokenError(mockTotals, mockThreshold);
     expect(error).to.have.a.property('message').that.is.a('string');
     expect(error).to.have.a.property('totals').that.is.an('object');
-    expect(error).to.have.a.property('totals').that.is.an('object');
-    expect(error.totals).to.have.a.property('failed');
-    expect(error.totals).to.have.a.property('timedOut');
-    expect(error.totals).to.have.a.property('total');
-    expect(error.totals).to.have.a.property('successful');
+    expect(error).to.have.a.property('totals').that.is.an('object').that.deep.equals(mockTotals);
   });
   it('Should have expected error string with calculated failure percentage', () => {
     const mockTotals = {


### PR DESCRIPTION
This PR creates a CircuitBrokenError class which has a more detailed error message and puts detailed request stats on the returned error object.

Example CircuitBrokenError:

```javascript
{
    message: 'Circuit has been broken - The percentage of failed requests (60%) is greater than the threshold specified (50%)',
    totals: {
        failed: 60,
        timedOut: 0,
        total: 100,
        successful: 40
    }
}
```