### PR TITLE
Add health check

### DIFF
--- a/examples/fallback-example.js
+++ b/examples/fallback-example.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const Brakes = require('../lib/Brakes');
+const timer = 100;
+let successRate = 2;
+let iterations = 0;
+
+function unreliableServiceCall() {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      iterations++;
+      if (iterations === 10) {
+        successRate = 0.6;
+      }
+      else if (iterations === 100) {
+        successRate = 0.1;
+      }
+      else if (iterations === 200) {
+        successRate = 1;
+      }
+
+
+      if (Math.random() <= successRate) {
+        resolve();
+      }
+      else {
+        reject();
+      }
+    }, timer);
+  });
+}
+
+
+const brake = new Brakes(unreliableServiceCall, {
+  statInterval: 2500,
+  threshold: 0.5,
+  circuitDuration: 15000,
+  timeout: 250
+});
+
+brake.on('snapshot', (snapshot) => {
+  console.log('Running at:', snapshot.stats.successful / snapshot.stats.total);
+  console.log(snapshot);
+});
+
+brake.on('circuitOpen', () => {
+  console.log('----------Circuit Opened--------------');
+});
+
+brake.on('circuitClosed', () => {
+  console.log('----------Circuit Closed--------------');
+});
+
+brake.fallback(() => {
+  console.log("Fallback");
+  return Promise.resolve();
+});
+
+setInterval(() => {
+  brake.exec()
+    .then(() => {
+      console.log('Successful');
+    })
+    .catch((err) => {
+      console.log('Failure', err || '');
+    });
+}, 100);

--- a/examples/healthCheck-example.js
+++ b/examples/healthCheck-example.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const Brakes = require('../lib/Brakes');
+const timer = 100;
+let successRate = 2;
+let iterations = 0;
+
+function unreliableServiceCall() {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      iterations++;
+      if (iterations === 10) {
+        successRate = 0.6;
+      }
+      else if (iterations === 100) {
+        successRate = 0.1;
+      }
+      else if (iterations === 200) {
+        successRate = 1;
+      }
+
+      if (Math.random() <= successRate) {
+        resolve();
+      }
+      else {
+        reject("Service Unavailable");
+      }
+    }, timer);
+  });
+}
+
+function anotherServiceCall(){
+  return Promise.resolve();
+}
+
+const brake = new Brakes(unreliableServiceCall, {
+  statInterval: 2500,
+  threshold: 0.5,
+  circuitDuration: 15000,
+  timeout: 250, 
+  healthCheckInterval: 500
+});
+
+brake.on('snapshot', (snapshot) => {
+  console.log('Running at:', snapshot.stats.successful / snapshot.stats.total);
+  console.log(snapshot);
+});
+
+brake.on('circuitOpen', () => {
+  console.log('----------Circuit Opened--------------');
+});
+
+brake.on('circuitClosed', () => {
+  console.log('----------Circuit Closed--------------');
+});
+
+brake.on('healthCheckFailed', err => {
+  console.log('--------Health check failed-----------', err || '');
+})
+
+brake.fallback(() => {
+  console.log("Fallback");
+  return Promise.resolve();
+});
+
+brake.healthCheck(() => {
+  console.log("checking health");
+  //in real world scenario, the health check should be done on a less load intensive way,
+  //like calling a function on server with the less data (like getting the version info),
+  //of trying to create a connection for mongodb
+  let healthCheckCalls = [unreliableServiceCall(), unreliableServiceCall(), anotherServiceCall()];
+
+  //health criteria = 2 times successful service calls to unreliableServiceCall and one to anotherServiceCall
+  return Promise.all(healthCheckCalls)
+      .then(results => console.log("health check success " + results));
+});
+
+setInterval(() => {
+  brake.exec()
+    .then(() => {
+      console.log('Successful');
+    })
+    .catch((err) => {
+      //this line should not be hit, as there is a fallback function
+      //(unless fallback is also failing)
+      console.log('Failure', err || '');
+    });
+}, 100);

--- a/lib/Brakes.js
+++ b/lib/Brakes.js
@@ -212,7 +212,7 @@ class Brakes extends EventEmitter {
     if (hasCallback(func)) {
       this._healthCheck = Promise.promisify(func);
     }
-    else{
+    else {
       this._healthCheck = func;
     }
   }

--- a/lib/Brakes.js
+++ b/lib/Brakes.js
@@ -21,8 +21,8 @@ const defaultOptions = {
   threshold: 0.5,
   timeout: 15000,
   healthCheckInterval: 5000,
-  healthCheck: undefined, //function can be assigned from options
-  fallback: undefined //function can be assigned from options
+  healthCheck: undefined,
+  fallback: undefined
 };
 
 class Brakes extends EventEmitter {
@@ -56,13 +56,13 @@ class Brakes extends EventEmitter {
       globalStats.register(this);
     }
 
-    //check if health check is in options
-    if (this._opts.healthCheck){
+    // check if health check is in options
+    if (this._opts.healthCheck) {
       this.healthCheck(this._opts.healthCheck);
     }
 
-    //check if fallback is in options
-    if (this._opts.fallback){
+    // check if fallback is in options
+    if (this._opts.fallback) {
       this.fallback(this._opts.fallback);
     }
   }
@@ -161,7 +161,7 @@ class Brakes extends EventEmitter {
     if (this._circuitOpen) return;
     this.emit('circuitOpen');
     this._circuitOpen = true;
-    if (this._healthCheck){
+    if (this._healthCheck) {
       this._setHealthInterval();
     }
     else {
@@ -169,12 +169,12 @@ class Brakes extends EventEmitter {
     }
   }
 
-  _setHealthInterval(){
+  _setHealthInterval() {
     const interval = setInterval(() => {
       if (this._circuitOpen) {
         this._healthCheck().then(() => {
-          //it is possible that in the meantime, the circuit is already
-          //closed by the previous health check
+          // it is possible that in the meantime, the circuit is already
+          // closed by the previous health check
           if (this._circuitOpen) {
             this._stats.reset();
             this._close();
@@ -183,19 +183,20 @@ class Brakes extends EventEmitter {
         }).catch(err => {
           this.emit('healthCheckFailed', err);
         });
-      } else {
-        //the circuit is closed out of health check,
-        //or from one of the cascading health checks
-        //(if the interval is not long enough to wait for one
-        //health check to complete, the previous health check might
-        //close the circuit) OR (manually closed).
+      }
+      else {
+        // the circuit is closed out of health check,
+        // or from one of the cascading health checks
+        // (if the interval is not long enough to wait for one
+        // health check to complete, the previous health check might
+        // close the circuit) OR (manually closed).
         clearInterval(interval);
       }
     }, this._opts.healthCheckInterval);
     interval.unref();
   }
 
-  _resetCircuitTimeout(){
+  _resetCircuitTimeout() {
     const timer = setTimeout(() => {
       this._stats.reset();
       this._close();
@@ -207,8 +208,8 @@ class Brakes extends EventEmitter {
   Allow user to pass a function to be used as a health check,
   to close the circuit if the function succeeds.
    */
-  healthCheck(func){
-    if (hasCallback(func)){
+  healthCheck(func) {
+    if (hasCallback(func)) {
       this._healthCheck = Promise.promisify(func);
     }
     else{

--- a/lib/Brakes.js
+++ b/lib/Brakes.js
@@ -20,7 +20,9 @@ const defaultOptions = {
   waitThreshold: 100,
   threshold: 0.5,
   timeout: 15000,
-  healthCheckInterval: 5000
+  healthCheckInterval: 5000,
+  healthCheck: undefined, //function can be assigned from options
+  fallback: undefined //function can be assigned from options
 };
 
 class Brakes extends EventEmitter {
@@ -52,6 +54,16 @@ class Brakes extends EventEmitter {
     // register with global stats collector
     if (this._opts.registerGlobal) {
       globalStats.register(this);
+    }
+
+    //check if health check is in options
+    if (this._opts.healthCheck){
+      this.healthCheck(this._opts.healthCheck);
+    }
+
+    //check if fallback is in options
+    if (this._opts.fallback){
+      this.fallback(this._opts.fallback);
     }
   }
 
@@ -150,26 +162,49 @@ class Brakes extends EventEmitter {
     this.emit('circuitOpen');
     this._circuitOpen = true;
     if (this._healthCheck){
-      const interval = setInterval(() => {
-        this._healthCheck().then(() => {
-          this._stats.reset();
-          this._close();
-          clearInterval(interval);
-        })
-      }, this._opts.healthCheckInterval);
-      interval.unref();
+      this._setHealthInterval();
     }
     else {
-      const timer = setTimeout(() => {
-        this._stats.reset();
-        this._close();
-      }, this._opts.circuitDuration);
-      timer.unref();
+      this._resetCircuitTimeout();
     }
   }
 
+  _setHealthInterval(){
+    const interval = setInterval(() => {
+      if (this._circuitOpen) {
+        this._healthCheck().then(() => {
+          //it is possible that in the meantime, the circuit is already
+          //closed by the previous health check
+          if (this._circuitOpen) {
+            this._stats.reset();
+            this._close();
+          }
+          clearInterval(interval);
+        }).catch(err => {
+          this.emit('healthCheckFailed', err);
+        });
+      } else {
+        //the circuit is closed out of health check,
+        //or from one of the cascading health checks
+        //(if the interval is not long enough to wait for one
+        //health check to complete, the previous health check might
+        //close the circuit) OR (manually closed).
+        clearInterval(interval);
+      }
+    }, this._opts.healthCheckInterval);
+    interval.unref();
+  }
+
+  _resetCircuitTimeout(){
+    const timer = setTimeout(() => {
+      this._stats.reset();
+      this._close();
+    }, this._opts.circuitDuration);
+    timer.unref();
+  }
+
   /*
-  Allow user to pass a function to be used as a healtcheck,
+  Allow user to pass a function to be used as a health check,
   to close the circuit if the function succeeds.
    */
   healthCheck(func){

--- a/lib/Brakes.js
+++ b/lib/Brakes.js
@@ -19,7 +19,8 @@ const defaultOptions = {
   registerGlobal: true,
   waitThreshold: 100,
   threshold: 0.5,
-  timeout: 15000
+  timeout: 15000,
+  healthCheckInterval: 5000
 };
 
 class Brakes extends EventEmitter {
@@ -148,11 +149,36 @@ class Brakes extends EventEmitter {
     if (this._circuitOpen) return;
     this.emit('circuitOpen');
     this._circuitOpen = true;
-    const timer = setTimeout(() => {
-      this._stats.reset();
-      this._close();
-    }, this._opts.circuitDuration);
-    timer.unref();
+    if (this._healthCheck){
+      const interval = setInterval(() => {
+        this._healthCheck().then(() => {
+          this._stats.reset();
+          this._close();
+          clearInterval(interval);
+        })
+      }, this._opts.healthCheckInterval);
+      interval.unref();
+    }
+    else {
+      const timer = setTimeout(() => {
+        this._stats.reset();
+        this._close();
+      }, this._opts.circuitDuration);
+      timer.unref();
+    }
+  }
+
+  /*
+  Allow user to pass a function to be used as a healtcheck,
+  to close the circuit if the function succeeds.
+   */
+  healthCheck(func){
+    if (hasCallback(func)){
+      this._healthCheck = Promise.promisify(func);
+    }
+    else{
+      this._healthCheck = func;
+    }
   }
 
   /*

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test": "node_modules/.bin/_mocha  $(find . -name '*.spec.js')",
     "test:lint": "node_modules/eslint/bin/eslint.js ./  || exit 0",
     "coverage": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- $(find . -name '*.spec.js')",
-    "coveralls": "cat ./coverage/lcov.info | node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+    "coveralls": "cat ./coverage/lcov.info | node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+    "coverage:win": "node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha ./tests/*.spec.js",
+    "test:win": "node_modules/.bin/_mocha ./tests/*.spec.js"
   },
   "keywords": [
     "circuit",

--- a/tests/Brakes.spec.js
+++ b/tests/Brakes.spec.js
@@ -20,7 +20,8 @@ const defaultOptions = {
   statInterval: 1200,
   waitThreshold: 100,
   threshold: 0.5,
-  timeout: 15000
+  timeout: 15000,
+  healthCheckInterval: 5000
 };
 
 const noop = function noop(foo, err, cb) {
@@ -44,6 +45,11 @@ const slowpr = function slowpr(foo) {
   });
 };
 const fbpr = function fallback(foo, err) {
+  return new Promise((resolve) => {
+    resolve(foo || err);
+  });
+};
+const hc = function healthCheck(foo, err) {
   return new Promise((resolve) => {
     resolve(foo || err);
   });
@@ -125,7 +131,8 @@ describe('Brakes Class', () => {
       group: 'fakeGroup',
       waitThreshold: 1000,
       threshold: 0.3,
-      timeout: 100
+      timeout: 100,
+      healthCheckInterval: 1000
     };
     brake = new Brakes(noop, overrides);
     expect(brake._opts).to.deep.equal(overrides);
@@ -189,6 +196,16 @@ describe('Brakes Class', () => {
     return brake.exec(null, 'thisShouldFailFirstCall').then(result => {
       expect(result).to.equal('thisShouldFailFirstCall');
     });
+  });
+  it('Should call healthCheck if circuit is broken', () => {
+    brake = new Brakes(nopr);
+    brake.healthCheck(fbpr);
+    const hcSpy = sinon.spy(brake, '_healthCheck');
+
+    brake._open();
+    setTimeout(() => {
+      expect(hcSpy.calledOnce).to.equal(true);
+    }, 500);
   });
   it('_open should open', (done) => {
     brake = new Brakes(nopr, {


### PR DESCRIPTION
Added a healthCheck function, that will start to execute when the
circuit is open. If the function is defined, it will overwrite the
timeout function which is automatically closing the circuit after
{circuitDuration} ms. The health check is used to check the external
system each {healthCheckInterval} and close the circuit only when the
external system is responding.

Example:
[testCircuitBreaker3.js.txt](https://github.com/awolden/brakes/files/346304/testCircuitBreaker3.js.txt)
