### PR TITLE
Update linting versions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,21 +1,17 @@
 {
   "extends": "airbnb-base",
-  "env": {
-    "mocha": true,
-    },
   "rules": {
-      "comma-dangle": 0,
-      "max-len": 0,
-      "brace-style" : [2, "stroustrup", {"allowSingleLine" : true}],
-      "no-console": 0,
-      "padded-blocks": 0,
-      "prefer-rest-params": 0,
-      "no-use-before-define": 0,
-      "strict": 0,
-      "no-param-reassign": 0,
-      "no-underscore-dangle": 0
-  },
-  "globals":{
-    "appRequire": true
+    "brace-style" : ["error", "stroustrup", {"allowSingleLine" : true}],
+    "arrow-parens" : ["error", "as-needed"],
+    "comma-dangle": "off",
+    "max-len": "off",
+    "prefer-rest-params": "off",
+    "no-use-before-define": "off",
+    "strict": "off",
+    "no-param-reassign": "off",
+    "no-underscore-dangle": "off",
+    "class-methods-use-this": "off",
+    "no-plusplus": "off",
+    "prefer-spread": "off"
   }
 }

--- a/lib/Brakes.js
+++ b/lib/Brakes.js
@@ -85,7 +85,7 @@ class Brakes extends EventEmitter {
     // the line below won't be needed with Node6, it provides
     // a method 'eventNames()'
     const eventNames = Object.keys(this._events);
-    eventNames.forEach((event) => {
+    eventNames.forEach(event => {
       this.removeAllListeners(event);
     });
   }
@@ -180,19 +180,19 @@ class Brakes extends EventEmitter {
   This is mostly used for stats monitoring
   */
   _attachListeners() {
-    this.on('success', (d) => {
+    this.on('success', d => {
       this._successHandler(d);
     });
-    this.on('timeout', (d) => {
+    this.on('timeout', d => {
       this._timeoutHandler(d);
     });
-    this.on('failure', (d) => {
+    this.on('failure', d => {
       this._failureHandler(d);
     });
-    this._stats.on('update', (d) => {
+    this._stats.on('update', d => {
       this._checkStats(d);
     });
-    this._stats.on('snapshot', (d) => {
+    this._stats.on('snapshot', d => {
       this._snapshotHandler(d);
     });
   }

--- a/lib/Bucket.js
+++ b/lib/Bucket.js
@@ -14,6 +14,7 @@ class Bucket {
 
   /* Calculate % of a given field */
   percent(field) {
+    // eslint-disable-next-line no-prototype-builtins
     if (!Object(this).hasOwnProperty(field)) {
       throw new Error(consts.INVALID_BUCKET_PROP);
     }

--- a/lib/Circuit.js
+++ b/lib/Circuit.js
@@ -63,10 +63,10 @@ class Circuit extends EventEmitter {
     // to allow us to more easily hook in stats reporting
     return this._execPromise
         .apply(this, arguments)
-        .then((result) => {
+        .then(result => {
           this._brakes.emit('success', new Date().getTime() - startTime);
           return result;
-        }).catch((err) => {
+        }).catch(err => {
           // trigger hook listeners
           if (err instanceof TimeOutError) {
             this._brakes.emit('timeout', new Date().getTime() - startTime);
@@ -91,16 +91,15 @@ class Circuit extends EventEmitter {
    */
   _execPromise() {
     return new Promise((resolve, reject) => {
-
       // start timeout timer
       const timeoutTimer = setTimeout(() => {
         reject(new TimeOutError(consts.TIMEOUT));
       }, this._opts.timeout || this._brakes._opts.timeout);
 
-      this._serviceCall.apply(this._this, arguments).then((result) => {
+      this._serviceCall.apply(this._this, arguments).then(result => {
         clearTimeout(timeoutTimer);
         resolve(result);
-      }).catch((err) => {
+      }).catch(err => {
         clearTimeout(timeoutTimer);
         reject(err);
       });

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -112,7 +112,7 @@ class Stats extends EventEmitter {
     if (includeLatencyStats) {
       tempTotals.requestTimes.sort((a, b) => a - b);
       tempTotals.latencyMean = this._calculateMean(tempTotals.requestTimes) || 0;
-      this._opts.percentiles.forEach((p) => {
+      this._opts.percentiles.forEach(p => {
         tempTotals.percentiles[p] =
           this._calculatePercentile(p, tempTotals.requestTimes) || 0;
       });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,8 +16,8 @@ function getFnArgs(fn) {
 
   // Split the arguments string into an array comma delimited.
   return args.split(', ')
-    .map((arg) => arg.replace(/\/\*.*\*\//, '').trim())
-    .filter((arg) => arg);
+    .map(arg => arg.replace(/\/\*.*\*\//, '').trim())
+    .filter(arg => arg);
 }
 
 /*

--- a/package.json
+++ b/package.json
@@ -34,17 +34,17 @@
   "author": "Alex Wolden <awolden@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "bluebird": "^3.3.5"
+    "bluebird": "^3.4.6"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-things": "^0.2.0",
-    "coveralls": "^2.11.12",
-    "eslint": "^2.9.0",
-    "eslint-config-airbnb-base": "^3.0.0",
-    "eslint-plugin-import": "^1.7.0",
-    "istanbul": "^0.4.3",
-    "mocha": "^3.0.0",
-    "sinon": "^1.17.3"
+    "coveralls": "^2.11.13",
+    "eslint": "^3.5.0",
+    "eslint-config-airbnb-base": "^7.1.0",
+    "eslint-plugin-import": "^1.15.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.0.2",
+    "sinon": "^1.17.5"
   }
 }

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }]
+  }
+}

--- a/tests/Brakes.spec.js
+++ b/tests/Brakes.spec.js
@@ -46,19 +46,19 @@ const nopr = function nopr(foo, err) {
   });
 };
 const slowpr = function slowpr(foo) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     setTimeout(() => {
       resolve(foo);
     }, 50);
   });
 };
 const fbpr = function fallback(foo, err) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     resolve(foo || err);
   });
 };
 const hc = function healthCheck(foo, err) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     resolve(foo || err);
   });
 };
@@ -94,19 +94,19 @@ describe('Brakes Class', () => {
     catch (e) {
       expect(e).to.be.an('error');
     }
-    return brake.exec('test').then(null, (err) => {
+    return brake.exec('test').then(null, err => {
       expect(err).to.be.an('error');
     });
   });
   it('Should promisify the service func', () => {
     brake = new Brakes(noop);
-    return brake.exec('test').then((result) => {
+    return brake.exec('test').then(result => {
       expect(result).to.equal('test');
     });
   });
   it('Should promisify and reject service func', () => {
     brake = new Brakes(noop);
-    return brake.exec(null, 'err').then(null, (err) => {
+    return brake.exec(null, 'err').then(null, err => {
       expect(err).to.be.instanceof(Error);
       expect(err.message).to.equal('err');
     });
@@ -114,13 +114,13 @@ describe('Brakes Class', () => {
 
   it('Should accept a promise', () => {
     brake = new Brakes(nopr);
-    return brake.exec('test').then((result) => {
+    return brake.exec('test').then(result => {
       expect(result).to.equal('test');
     });
   });
   it('Should reject a promise', () => {
     brake = new Brakes(nopr);
-    return brake.exec(null, 'err').then(null, (err) => {
+    return brake.exec(null, 'err').then(null, err => {
       expect(err).to.be.instanceof(Error);
       expect(err.message).to.equal('err');
     });
@@ -224,7 +224,7 @@ describe('Brakes Class', () => {
       expect(result).to.equal('thisShouldFailFirstCall');
     });
   });
-  it('Should close circuit if _setHealthInterval is called with successful health check', (done) => {
+  it('Should close circuit if _setHealthInterval is called with successful health check', done => {
     brake = new Brakes(nopr, {
       healthCheckInterval: 1
     });
@@ -257,7 +257,7 @@ describe('Brakes Class', () => {
     });
     expect(brake._healthCheck('foo').then).to.not.equal(undefined);
   });
-  it('_setHealthInterval should open', (done) => {
+  it('_setHealthInterval should open', done => {
     brake = new Brakes(nopr, {
       healthCheck: hc,
       healthCheckInterval: 1
@@ -275,7 +275,7 @@ describe('Brakes Class', () => {
       done();
     }, 5);
   });
-  it('_setHealthInterval should emit error', (done) => {
+  it('_setHealthInterval should emit error', done => {
     brake = new Brakes(nopr, {
       healthCheck: nopr.bind(null, null, 'thisisanerror'),
       healthCheckInterval: 0
@@ -303,7 +303,7 @@ describe('Brakes Class', () => {
     brake._setHealthInterval();
     expect(brake._healthInterval).to.equal('foo');
   });
-  it('_setHealthInterval should clearInterval, if circuit is opened', (done) => {
+  it('_setHealthInterval should clearInterval, if circuit is opened', done => {
     brake = new Brakes(nopr, {
       healthCheck: hc,
       healthCheckInterval: 0
@@ -315,7 +315,7 @@ describe('Brakes Class', () => {
       done();
     }, 3);
   });
-  it('_open should open', (done) => {
+  it('_open should open', done => {
     brake = new Brakes(nopr, {
       circuitDuration: 10
     });
@@ -342,7 +342,6 @@ describe('Brakes Class', () => {
       expect(openSpy.calledOnce).to.equal(true);
       done();
     }, 20);
-
   });
   it('_close should close', () => {
     brake = new Brakes(nopr);
@@ -353,7 +352,7 @@ describe('Brakes Class', () => {
     expect(brake._circuitOpen).to.equal(false);
     expect(eventSpy.calledOnce).to.equal(true);
   });
-  it('_snapshotHandler should transform stats object and emit', (done) => {
+  it('_snapshotHandler should transform stats object and emit', done => {
     brake = new Brakes(nopr, {
       name: 'brake1',
       group: 'brakeGroup1',

--- a/tests/Circuit.spec.js
+++ b/tests/Circuit.spec.js
@@ -23,14 +23,14 @@ const nopr = function nopr(foo, err) {
   });
 };
 const slowpr = function slowpr(foo) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     setTimeout(() => {
       resolve(foo);
     }, 50);
   });
 };
 const fbpr = function fallback(foo, err) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     resolve(foo || err);
   });
 };
@@ -56,14 +56,14 @@ describe('Circuit Class', () => {
   it('Should promisify the service func', () => {
     brake = new Brakes(noop);
     const circuit = new Circuit(brake, noop);
-    return circuit._serviceCall('test').then((result) => {
+    return circuit._serviceCall('test').then(result => {
       expect(result).to.equal('test');
     });
   });
   it('Should promisify and reject service func', () => {
     brake = new Brakes(noop);
     const circuit = new Circuit(brake, noop);
-    return circuit._serviceCall(null, 'err').then(null, (err) => {
+    return circuit._serviceCall(null, 'err').then(null, err => {
       expect(err).to.be.instanceof(Error);
       expect(err.message).to.equal('err');
     });
@@ -71,14 +71,14 @@ describe('Circuit Class', () => {
   it('Should accept a promise', () => {
     brake = new Brakes(nopr);
     const circuit = new Circuit(brake, nopr);
-    return circuit._serviceCall('test').then((result) => {
+    return circuit._serviceCall('test').then(result => {
       expect(result).to.equal('test');
     });
   });
   it('Should reject a promise', () => {
     brake = new Brakes(nopr);
     const circuit = new Circuit(brake, nopr);
-    return circuit._serviceCall(null, 'err').then(null, (err) => {
+    return circuit._serviceCall(null, 'err').then(null, err => {
       expect(err).to.be.instanceof(Error);
       expect(err.message).to.equal('err');
     });

--- a/tests/CircuitBrokenError.spec.js
+++ b/tests/CircuitBrokenError.spec.js
@@ -37,5 +37,4 @@ describe('CircuitBrokenError', () => {
     const mockThreshold = 0.5;
     expect(new CircuitBrokenError(mockTotals, mockThreshold)).to.have.a.property('message').that.equals(`${consts.CIRCUIT_OPENED} - The percentage of failed requests (60%) is greater than the threshold specified (50%)`);
   });
-
 });

--- a/tests/Stats.spec.js
+++ b/tests/Stats.spec.js
@@ -2,11 +2,12 @@
 
 const Stats = require('../lib/Stats');
 const chai = require('chai');
-chai.use(require('chai-things'));
-const expect = chai.expect;
 const EventEmitter = require('events').EventEmitter;
 const Bucket = require('../lib/Bucket');
 const sinon = require('sinon');
+
+const expect = chai.expect;
+chai.use(require('chai-things'));
 
 const defaultOptions = {
   bucketSpan: 1000,
@@ -47,7 +48,7 @@ describe('Stats Class', () => {
     const stats = new Stats();
     expect(stats._activeBucket).to.equal(stats._buckets[stats._buckets.length - 1]);
   });
-  it('Should start bucket spinning automatically', (done) => {
+  it('Should start bucket spinning automatically', done => {
     const stats = new Stats({
       bucketSpan: 10
     });
@@ -65,7 +66,7 @@ describe('Stats Class', () => {
     // test 2nd call
     expect(stats._stopBucketSpinning()).to.equal(false);
   });
-  it('Should start stats snapshotting', (done) => {
+  it('Should start stats snapshotting', done => {
     const stats = new Stats();
     stats.startSnapshots(10);
     const spy = sinon.spy(stats, '_snapshot');

--- a/tests/globalStats.spec.js
+++ b/tests/globalStats.spec.js
@@ -7,7 +7,6 @@ const sinon = require('sinon');
 const utils = require('../lib/utils');
 
 describe('globalStats', () => {
-
   it('should construct appropriately', () => {
     expect(globalStats._rawStream).to.be.instanceof(stream.Readable);
     expect(globalStats._rawStream._read).to.be.a('function');
@@ -56,11 +55,11 @@ describe('globalStats', () => {
     globalStats._rawStream.push.restore();
   });
 
-  it('_transformToHysterix() should transform to hysterix', (done) => {
+  it('_transformToHysterix() should transform to hysterix', done => {
     const mock = {
       foo: 'bar'
     };
-    const stub = sinon.stub(utils, 'mapToHystrixJson', (data) => data);
+    const stub = sinon.stub(utils, 'mapToHystrixJson', data => data);
     globalStats._transformToHysterix(JSON.stringify(mock), null, (err, data) => {
       expect(stub.calledOnce).to.equal(true);
       expect(data).to.equal(`data: ${JSON.stringify(mock)}\n\n`);
@@ -75,6 +74,5 @@ describe('globalStats', () => {
 
   it('getHystrixStream() should return hysterixStream stream', () => {
     expect(globalStats.getHystrixStream()).to.equal(globalStats._hystrixStream);
-
   });
 });

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -5,7 +5,6 @@ const expect = require('chai').expect;
 
 
 describe('utils', () => {
-
   describe('hasCallback', () => {
     it('should return true', () => {
       // standard
@@ -48,7 +47,6 @@ describe('utils', () => {
       passed = utils.hasCallback(fakey.foo);
       expect(passed).to.equal(false);
     });
-
   });
   describe('getFnArgs', () => {
     it('should return a list of arguments', () => {
@@ -154,5 +152,4 @@ describe('utils', () => {
       });
     });
   });
-
 });


### PR DESCRIPTION
Hi again,

This PR updates eslint and airbnb config to the latest versions.

Version 3 of ESLint has a LOT more rules as fixable, meaning you can run `eslint . --fix` (or `npm run test:lint -- --fix`) to fix almost every error reported automatically. I didn't change single line of code myself (except for the single ignore and moving non-`require`s out of other `require`s), `--fix` did it all.