### PR TITLE
Add `exec` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ isOpen|N/A|boolean|Returns `true` if circuit is open
 ## Events
   Every brake is an instance of `EventEmitter` that provides the following events:
 
+  - **exec**: Event on request start
   - **failure**: Event on request failure
   - **success**: Event on request success
   - **timeout**: Event on request timeout

--- a/lib/Circuit.js
+++ b/lib/Circuit.js
@@ -49,6 +49,8 @@ class Circuit extends EventEmitter {
   }
 
   exec() {
+    this._brakes.emit('exec');
+
     if (this._brakes._circuitOpen) {
       this._brakes._stats.shortCircuit();
       if (this._fallback) {

--- a/test/Circuit.spec.js
+++ b/test/Circuit.spec.js
@@ -111,6 +111,16 @@ describe('Circuit Class', () => {
       circuit.test();
     }).to.throw();
   });
+  it('Should trigger event on exec', () => {
+    brake = new Brakes(nopr);
+    const circuit = new Circuit(brake, nopr);
+    const spy = sinon.spy(() => {});
+    brake.on('exec', spy);
+    return circuit.exec('foo').then(result => {
+      expect(result).to.equal('foo');
+      expect(spy.calledOnce).to.equal(true);
+    });
+  });
   it('Should Resolve a service call and trigger event', () => {
     brake = new Brakes(nopr);
     const circuit = new Circuit(brake, nopr);


### PR DESCRIPTION
We use prometheus to count this now, and to be able to migrate to this module, this event has to be present.

I suppose we'd get the same number from Hystrix, but still.

See #43 for fixed CI