### PR TITLE
Add the breaker name to rejections

### DIFF
--- a/lib/Circuit.js
+++ b/lib/Circuit.js
@@ -57,7 +57,7 @@ class Circuit extends EventEmitter {
       else if (this._brakes._fallback) {
         return this._brakes._fallback.apply(this, arguments);
       }
-      return Promise.reject(new CircuitBrokenError(this._brakes._stats._totals, this._brakes._opts.threshold));
+      return Promise.reject(new CircuitBrokenError(this._brakes.name, this._brakes._stats._totals, this._brakes._opts.threshold));
     }
 
     const startTime = Date.now();
@@ -86,6 +86,10 @@ class Circuit extends EventEmitter {
         }
         else if (this._brakes._fallback) {
           return this._brakes._fallback.apply(this, arguments);
+        }
+
+        if (err.message && this._brakes.name) {
+          err.message = `[Breaker: ${this._brakes.name}] ${err.message}`;
         }
 
         return Promise.reject(err);

--- a/lib/CircuitBrokenError.js
+++ b/lib/CircuitBrokenError.js
@@ -3,11 +3,18 @@
 const consts = require('./consts');
 
 class CircuitBrokenError extends Error {
-  constructor(totals, threshold) {
+  constructor(name, totals, threshold) {
     super();
 
-    this.message = `${consts.CIRCUIT_OPENED} - The percentage of failed requests (${Math.floor((1 - totals.successful / totals.total) * 100)}%) is greater than the threshold specified (${threshold * 100}%)`;
+    let prefix = '';
+
+    if (name) {
+      prefix = `[Breaker: ${name}] `;
+    }
+
+    this.message = `${prefix}${consts.CIRCUIT_OPENED} - The percentage of failed requests (${Math.floor((1 - totals.successful / totals.total) * 100)}%) is greater than the threshold specified (${threshold * 100}%)`;
     this.totals = totals;
+    this.name = name;
   }
 }
 

--- a/test/Brakes.spec.js
+++ b/test/Brakes.spec.js
@@ -110,7 +110,7 @@ describe('Brakes Class', () => {
     brake = new Brakes(noop);
     return brake.exec(null, 'err').then(null, err => {
       expect(err).to.be.instanceof(Error);
-      expect(err.message).to.equal('err');
+      expect(err.message).to.equal('[Breaker: defaultBrake] err');
     });
   });
 
@@ -124,7 +124,7 @@ describe('Brakes Class', () => {
     brake = new Brakes(nopr);
     return brake.exec(null, 'err').then(null, err => {
       expect(err).to.be.instanceof(Error);
-      expect(err.message).to.equal('err');
+      expect(err.message).to.equal('[Breaker: defaultBrake] err');
     });
   });
   it('Throw an error if not passed a function', () => {
@@ -183,7 +183,7 @@ describe('Brakes Class', () => {
     brake.on('failure', spy);
     return brake.exec(null, 'err').then(null, err => {
       expect(err).to.be.instanceof(Error);
-      expect(err.message).to.equal('err');
+      expect(err.message).to.equal('[Breaker: defaultBrake] err');
       expect(spy.calledOnce).to.equal(true);
     });
   });

--- a/test/Circuit.spec.js
+++ b/test/Circuit.spec.js
@@ -138,7 +138,7 @@ describe('Circuit Class', () => {
     brake.on('failure', spy);
     return circuit.exec(null, 'err').then(null, err => {
       expect(err).to.be.instanceof(Error);
-      expect(err.message).to.equal('err');
+      expect(err.message).to.equal('[Breaker: defaultBrake] err');
       expect(spy.calledOnce).to.equal(true);
       expect(spy.getCall(0).args[1]).to.equal(err);
     });
@@ -210,8 +210,10 @@ describe('Circuit Class', () => {
     brake = new Brakes(nopr);
     const circuit = new Circuit(brake, nopr);
     brake._circuitOpen = true;
+    brake._failureHandler(100);
     return circuit.exec('test').then(null, err => {
       expect(err).to.be.instanceof(CircuitBrokenError);
+      expect(err.message).to.equal('[Breaker: defaultBrake] Circuit has been opened - The percentage of failed requests (100%) is greater than the threshold specified (50%)');
     });
   });
   it('Should not count as failure if `isFailure` returns `false`', () => {
@@ -221,7 +223,7 @@ describe('Circuit Class', () => {
     brake.on('failure', spy);
     return circuit.exec(null, 'err').then(null, err => {
       expect(err).to.be.instanceof(Error);
-      expect(err.message).to.equal('err');
+      expect(err.message).to.equal('[Breaker: defaultBrake] err');
       expect(spy.called).to.equal(false);
     });
   });

--- a/test/CircuitBrokenError.spec.js
+++ b/test/CircuitBrokenError.spec.js
@@ -13,7 +13,7 @@ describe('CircuitBrokenError', () => {
       successful: 40
     };
     const mockThreshold = 0.5;
-    expect(new CircuitBrokenError(mockTotals, mockThreshold)).to.be.instanceof(Error);
+    expect(new CircuitBrokenError('defaultBrake', mockTotals, mockThreshold)).to.be.instanceof(Error);
   });
   it('Should contain expected properties', () => {
     const mockTotals = {
@@ -22,12 +22,14 @@ describe('CircuitBrokenError', () => {
       total: 100,
       successful: 40
     };
+    const breakerName = 'Some fancy braker name';
     const mockThreshold = 0.5;
-    const error = new CircuitBrokenError(mockTotals, mockThreshold);
+    const error = new CircuitBrokenError(breakerName, mockTotals, mockThreshold);
     expect(error).to.have.a.property('message').that.is.a('string');
     expect(error).to.have.a.property('totals').that.is.an('object').that.deep.equals(mockTotals);
+    expect(error).to.have.a.property('name').that.is.a('string').that.equals(breakerName);
   });
-  it('Should have expected error string with calculated failure percentage', () => {
+  it('Should have expected error string with name of breaker and calculated failure percentage', () => {
     const mockTotals = {
       failed: 60,
       timedOut: 0,
@@ -35,6 +37,16 @@ describe('CircuitBrokenError', () => {
       successful: 40
     };
     const mockThreshold = 0.5;
-    expect(new CircuitBrokenError(mockTotals, mockThreshold)).to.have.a.property('message').that.equals(`${consts.CIRCUIT_OPENED} - The percentage of failed requests (60%) is greater than the threshold specified (50%)`);
+    expect(new CircuitBrokenError('defaultBrake', mockTotals, mockThreshold)).to.have.a.property('message').that.equals(`[Breaker: defaultBrake] ${consts.CIRCUIT_OPENED} - The percentage of failed requests (60%) is greater than the threshold specified (50%)`);
+  });
+  it("Should not decorate the message with the name of the breaker if it's missing", () => {
+    const mockTotals = {
+      failed: 60,
+      timedOut: 0,
+      total: 100,
+      successful: 40
+    };
+    const mockThreshold = 0.5;
+    expect(new CircuitBrokenError('', mockTotals, mockThreshold)).to.have.a.property('message').that.equals(`${consts.CIRCUIT_OPENED} - The percentage of failed requests (60%) is greater than the threshold specified (50%)`);
   });
 });


### PR DESCRIPTION
Not sure if you want this, but we find it practical when debugging and tracing through logs.
