### PR TITLE
Add missing hystrix field

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -85,7 +85,7 @@ class Stats extends EventEmitter {
     const tempTotals = buckets.reduce((prev, cur) => {
       if (!cur) return prev;
 
-      // aggregrate incremented stats
+      // aggregate incremented stats
       prev.total += cur.total || 0;
       prev.failed += cur.failed || 0;
       prev.timedOut += cur.timedOut || 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,6 +34,7 @@ function mapToHystrixJson(json) {
     errorPercentage: (stats.total) ? stats.failed / stats.total : 0,
     errorCount: stats.failed,
     requestCount: stats.total,
+    rollingCountBadRequests: 0, // not reported
     rollingCountCollapsedRequests: 0, // not reported
     rollingCountExceptionsThrown: 0, // not reported
     rollingCountFailure: stats.failed,

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -96,6 +96,7 @@ describe('utils', () => {
         errorPercentage: (stats.total) ? stats.failed / stats.total : 0,
         errorCount: stats.failed,
         requestCount: stats.total,
+        rollingCountBadRequests: 0, // not reported
         rollingCountCollapsedRequests: 0, // not reported
         rollingCountExceptionsThrown: 0, // not reported
         rollingCountFailure: stats.failed,


### PR DESCRIPTION
Without this, Turbine throws: `ReferenceError: rollingCountBadRequests is not defined(…)`

https://github.com/Netflix/Hystrix/wiki/Metrics-and-Monitoring#cumulative-and-rolling-event-counts