### PR TITLE
Do not push new data when stream is paused

### DIFF
--- a/lib/globalStats.js
+++ b/lib/globalStats.js
@@ -52,7 +52,9 @@ class GlobalStats {
   /* listen to event and pipe to stream */
   _globalListener(stats) {
     if (!stats || typeof stats !== 'object') return;
-    this._rawStream.push(JSON.stringify(stats));
+    if (!this._rawStream.isPaused()) {
+      this._rawStream.push(JSON.stringify(stats));
+    }
   }
 
   /* transform stats object into hystrix object */


### PR DESCRIPTION
Fixes a memory leak. Once a stream was connected, then disconnected, this would buffer stats data since no readers were attached at the rate of ~25 MB/hr.