### PR TITLE
Hystrix reporting converts error percentage to int

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,7 +31,7 @@ function mapToHystrixJson(json) {
     group: json.group,
     currentTime: json.time,
     isCircuitBreakerOpen: json.open,
-    errorPercentage: (stats.total) ? (1 - stats.successful / stats.total) * 100 : 0,
+    errorPercentage: (stats.total) ? Math.round((1 - stats.successful / stats.total) * 100) : 0,
     errorCount: stats.failed,
     requestCount: stats.total,
     rollingCountBadRequests: 0, // not reported

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -93,7 +93,7 @@ describe('utils', () => {
         group: 'defaultBrakeGroup',
         currentTime: 1463292683341,
         isCircuitBreakerOpen: statsOutput.open,
-        errorPercentage: (stats.total) ? (1 - stats.successful / stats.total) * 100 : 0,
+        errorPercentage: (stats.total) ? Math.round((1 - stats.successful / stats.total) * 100) : 0,
         errorCount: stats.failed,
         requestCount: stats.total,
         rollingCountBadRequests: 0, // not reported


### PR DESCRIPTION
Fixes and issue where some versions of turbine were failing to cast a float to an int when aggregating streams.