### PR TITLE
Include error in timeout and failure event

### DIFF
--- a/lib/Circuit.js
+++ b/lib/Circuit.js
@@ -70,10 +70,10 @@ class Circuit extends EventEmitter {
 
         // trigger hook listeners
         if (err instanceof TimeOutError) {
-          this._brakes.emit('timeout', endTime);
+          this._brakes.emit('timeout', endTime, err);
         }
         else if (this._opts.isFailure(err)) {
-          this._brakes.emit('failure', endTime);
+          this._brakes.emit('failure', endTime, err);
         }
         // if fallback exists, call it upon failure
         // there are no listeners or stats collection for

--- a/test/Circuit.spec.js
+++ b/test/Circuit.spec.js
@@ -140,6 +140,7 @@ describe('Circuit Class', () => {
       expect(err).to.be.instanceof(Error);
       expect(err.message).to.equal('err');
       expect(spy.calledOnce).to.equal(true);
+      expect(spy.getCall(0).args[1]).to.equal(err);
     });
   });
   it('Should timeout a service call and trigger event', () => {
@@ -150,6 +151,7 @@ describe('Circuit Class', () => {
     return circuit.exec(null, 'err').then(null, err => {
       expect(err).to.be.instanceof(TimeOutError);
       expect(spy.calledOnce).to.equal(true);
+      expect(spy.getCall(0).args[1]).to.equal(err);
     });
   });
   it('Should timeout a service call and trigger event (brake override)', () => {


### PR DESCRIPTION
Useful if I have a fallback set up, otherwise the error is unavailable to me.