### PR TITLE
Fix for #83

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,17 @@ function promisifyIfFunction(fn, isPromise, isFunction) {
  * Return a list arguments for a function
  */
 function getFnArgs(fn) {
-  const args = fn.toString().match(/^[function\s]?.*?\(([^)]*)\)/)[1];
+  const match = fn.toString().match(/^[function\s]?.*?\(([^)]*)\)/);
+  let args = '';
+  if (!match) {
+    const matchSingleArg = fn.toString().match(/^([^)]*) =>/);
+    if (matchSingleArg) {
+      args = matchSingleArg[1];
+    }
+  }
+  else {
+    args = match[1];
+  }
 
   // Split the arguments string into an array comma delimited.
   return args.split(', ')

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -19,6 +19,12 @@ describe('utils', () => {
       });
       expect(passed).to.equal(true);
 
+      // anonymous, single arg fat arrow
+      passed = utils.hasCallback(callback =>
+        callback()
+      );
+      expect(passed).to.equal(true);
+
       // class
       class FakeClass {
         foo(err, done) {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -39,6 +39,12 @@ describe('utils', () => {
       passed = utils.hasCallback(() => {});
       expect(passed).to.equal(false);
 
+      // anonymous, single arg fat arrow
+      passed = utils.hasCallback(foo =>
+        `${foo}bar`
+      );
+      expect(passed).to.equal(false);
+
       // class
       class FakeClass {
         foo() {}


### PR DESCRIPTION
Adds support for single arg fat arrow functions without parens