### PR TITLE
Added circuit generations to prevent timeouts from bleeding between c…

### DIFF
--- a/lib/Brakes.js
+++ b/lib/Brakes.js
@@ -41,6 +41,8 @@ class Brakes extends EventEmitter {
     this._opts = Object.assign({}, defaultOptions, opts);
     this._stats = new Stats(opts);
 
+    this._circuitGeneration = 1;
+
     this.name = this._opts.name;
     this.group = this._opts.group;
 
@@ -110,6 +112,7 @@ class Brakes extends EventEmitter {
     if (this._circuitOpen) return;
     this.emit('circuitOpen');
     this._circuitOpen = true;
+    this._circuitGeneration++;
     if (this._healthCheck) {
       this._setHealthInterval();
     }
@@ -182,11 +185,11 @@ class Brakes extends EventEmitter {
     this.on('success', d => {
       this._successHandler(d);
     });
-    this.on('timeout', d => {
-      this._timeoutHandler(d);
+    this.on('timeout', (d, error, execGeneration) => {
+      this._timeoutHandler(d, execGeneration);
     });
-    this.on('failure', d => {
-      this._failureHandler(d);
+    this.on('failure', (d, error, execGeneration) => {
+      this._failureHandler(d, execGeneration);
     });
     this._stats.on('update', d => {
       this._checkStats(d);
@@ -229,12 +232,16 @@ class Brakes extends EventEmitter {
     this._stats.success(runTime);
   }
 
-  _timeoutHandler(runTime) {
-    this._stats.timeout(runTime);
+  _timeoutHandler(runTime, execGeneration) {
+    if (execGeneration === this._circuitGeneration) {
+      this._stats.timeout(runTime);
+    }
   }
 
-  _failureHandler(runTime) {
-    this._stats.failure(runTime);
+  _failureHandler(runTime, execGeneration) {
+    if (execGeneration === this._circuitGeneration) {
+      this._stats.failure(runTime);
+    }
   }
 
   slaveCircuit(service, fallback, options) {

--- a/lib/Circuit.js
+++ b/lib/Circuit.js
@@ -49,6 +49,11 @@ class Circuit extends EventEmitter {
   exec() {
     this._brakes.emit('exec');
 
+    // Save circuit generation to scope so we can compare it
+    // to the current generation when a request fails.
+    // This prevents failures from bleeding between circuit generations.
+    const execGeneration = this._brakes._circuitGeneration;
+
     if (this._brakes._circuitOpen) {
       this._brakes._stats.shortCircuit();
       if (this._fallback) {
@@ -72,10 +77,10 @@ class Circuit extends EventEmitter {
 
         // trigger hook listeners
         if (err instanceof TimeOutError) {
-          this._brakes.emit('timeout', endTime, err);
+          this._brakes.emit('timeout', endTime, err, execGeneration);
         }
         else if (this._opts.isFailure(err)) {
-          this._brakes.emit('failure', endTime, err);
+          this._brakes.emit('failure', endTime, err, execGeneration);
         }
         // if fallback exists, call it upon failure
         // there are no listeners or stats collection for

--- a/test/Brakes.spec.js
+++ b/test/Brakes.spec.js
@@ -324,6 +324,7 @@ describe('Brakes Class', () => {
     brake._circuitOpen = false;
     brake._open();
 
+    expect(brake._circuitGeneration).to.equal(2);
     expect(brake._circuitOpen).to.equal(true);
     expect(eventSpy.calledOnce).to.equal(true);
 
@@ -402,6 +403,22 @@ describe('Brakes Class', () => {
     brake = new Brakes(nopr);
     expect(brake.getGlobalStats()).to.equal(globalStats);
     expect(Brakes.getGlobalStats()).to.equal(globalStats);
+  });
+  it('_failureHandler should not register a stats failure if generations do not match', () => {
+    brake = new Brakes(nopr);
+    sinon.stub(brake._stats, 'failure');
+    brake._circuitGeneration = 20;
+    brake._failureHandler(100, 19);
+    expect(brake._stats.failure.callCount).to.equal(0);
+    brake._stats.failure.restore();
+  });
+  it('_timeoutHandler should not register a stats timeout if generations do not match', () => {
+    brake = new Brakes(nopr);
+    sinon.stub(brake._stats, 'timeout');
+    brake._circuitGeneration = 20;
+    brake._timeoutHandler(100, 19);
+    expect(brake._stats.timeout.callCount).to.equal(0);
+    brake._stats.timeout.restore();
   });
   it('_checkStats should not check when threshold isn\'t met', () => {
     brake = new Brakes(nopr);

--- a/test/Circuit.spec.js
+++ b/test/Circuit.spec.js
@@ -210,7 +210,7 @@ describe('Circuit Class', () => {
     brake = new Brakes(nopr);
     const circuit = new Circuit(brake, nopr);
     brake._circuitOpen = true;
-    brake._failureHandler(100);
+    brake._failureHandler(100, 1);
     return circuit.exec('test').then(null, err => {
       expect(err).to.be.instanceof(CircuitBrokenError);
       expect(err.message).to.equal('[Breaker: defaultBrake] Circuit has been opened - The percentage of failed requests (100%) is greater than the threshold specified (50%)');


### PR DESCRIPTION
Adds in the concept of `circuit generations`. A generation will be an integer that increments by one every time a circuit is opened. Service requests will be tagged with a generation and the generation will be checked on failed response to make sure we don't inadvertently pollute the current circuit with requests that are from a previous circuit generation.