### PR TITLE
Added cumulative statistics to support request counter

### DIFF
--- a/lib/Bucket.js
+++ b/lib/Bucket.js
@@ -3,13 +3,14 @@
 const consts = require('./consts');
 
 class Bucket {
-  constructor() {
+  constructor(cumStats) {
     this.failed = 0;
     this.successful = 0;
     this.total = 0;
     this.shortCircuited = 0;
     this.timedOut = 0;
     this.requestTimes = [];
+    this.cummulativeStats = cumStats;
   }
 
   /* Calculate % of a given field */
@@ -29,26 +30,40 @@ class Bucket {
   /* Register a failure */
   failure(runTime) {
     this.total++;
+    this.cummulativeStats.countTotal++;
+    this.cummulativeStats.countTotalDeriv++;
     this.failed++;
+    this.cummulativeStats.countFailure++;
+    this.cummulativeStats.countFailureDeriv++;
     this.requestTimes.push(runTime);
   }
 
   /* Register a success */
   success(runTime) {
     this.total++;
+    this.cummulativeStats.countTotal++;
+    this.cummulativeStats.countTotalDeriv++;
     this.successful++;
+    this.cummulativeStats.countSuccess++;
+    this.cummulativeStats.countSuccessDeriv++;
     this.requestTimes.push(runTime);
   }
 
   /* Register a short circuit */
   shortCircuit() {
     this.shortCircuited++;
+    this.cummulativeStats.countShortCircuited++;
+    this.cummulativeStats.countShortCircuitedDeriv++;
   }
 
   /* Register a timeout */
   timeout(runTime) {
     this.total++;
+    this.cummulativeStats.countTotal++;
+    this.cummulativeStats.countTotalDeriv++;
     this.timedOut++;
+    this.cummulativeStats.countTimeout++;
+    this.cummulativeStats.countTimeoutDeriv++;
     this.requestTimes.push(runTime);
   }
 }

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -17,19 +17,39 @@ class Stats extends EventEmitter {
     this._opts = Object.assign({}, defaultOptions, opts);
     this._activePosition = this._opts.bucketNum - 1;
 
+    this._cummulative = {
+      // Total count of requests, failures, etc.
+      countTotal: 0,
+      countSuccess: 0,
+      countFailure: 0,
+      countTimeout: 0,
+      countShortCircuited: 0,
+      // Derivate in between two measurements to support counters that only increase (e.g., prom-client)
+      countTotalDeriv: 0,
+      countSuccessDeriv: 0,
+      countFailureDeriv: 0,
+      countTimeoutDeriv: 0,
+      countShortCircuitedDeriv: 0,
+    };
+
     // initialize buckets
     this._buckets = [];
     for (let i = 0; i < this._opts.bucketNum; i++) {
-      this._buckets.push(new Bucket());
+      this._buckets.push(new Bucket(this._cummulative));
     }
+
     this._activeBucket = this._buckets[this._activePosition];
     this._startBucketSpinning();
     this._totals = this._generateStats(this._buckets, true);
   }
 
+  getCummulateiveSatistics() {
+    return this._cummulative;
+  }
+
   reset() {
     for (let i = 0; i < this._opts.bucketNum; i++) {
-      this._shiftAndPush(this._buckets, new Bucket());
+      this._shiftAndPush(this._buckets, new Bucket(this._cummulative));
     }
     this._activeBucket = this._buckets[this._activePosition];
     this._update();
@@ -38,7 +58,7 @@ class Stats extends EventEmitter {
   /* Starts cycling through buckets */
   _startBucketSpinning() {
     this._spinningInterval = setInterval(() => {
-      this._shiftAndPush(this._buckets, new Bucket());
+      this._shiftAndPush(this._buckets, new Bucket(this._cummulative));
       this._activeBucket = this._buckets[this._activePosition];
     }, this._opts.bucketSpan);
     this._spinningInterval.unref();
@@ -128,7 +148,17 @@ class Stats extends EventEmitter {
     delete tempTotals.requestTimes;
     this._totals = tempTotals;
 
+    this._totals = Object.assign(this._totals, this._cummulative);
+
     return this._totals;
+  }
+
+  _resetDerivs() {
+    this._cummulative.countTotalDeriv = 0;
+    this._cummulative.countSuccessDeriv = 0;
+    this._cummulative.countFailureDeriv = 0;
+    this._cummulative.countTimeoutDeriv = 0;
+    this._cummulative.countShortCircuitedDeriv = 0;
   }
 
   /*
@@ -165,6 +195,7 @@ class Stats extends EventEmitter {
   /* Send snapshot stats event */
   _snapshot() {
     this.emit('snapshot', this._generateStats(this._buckets, true));
+    this._resetDerivs();
   }
 
   /* Register a failure */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -111,7 +111,19 @@ function mapToHystrixJson(json) {
     propertyValue_metricsRollingStatisticalWindowInMilliseconds: 10000, //  not reported
     propertyValue_requestCacheEnabled: false, // not reported
     propertyValue_requestLogEnabled: false, // not reported
-    reportingHosts: 1 // not reported
+    reportingHosts: 1, // not reported
+
+    countTotal: stats.countTotal,
+    countSuccess: stats.countSuccess,
+    countFailure: stats.countFailure,
+    countTimeout: stats.countTimeout,
+    countShortCircuited: stats.countShortCircuited,
+
+    countTotalDeriv: stats.countTotalDeriv,
+    countSuccessDeriv: stats.countSuccessDeriv,
+    countFailureDeriv: stats.countFailureDeriv,
+    countTimeoutDeriv: stats.countTimeoutDeriv,
+    countShortCircuitedDeriv: stats.countShortCircuitedDeriv,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brakes",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Node.js Circuit Breaker Pattern",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
   "devDependencies": {
     "chai": "^4.0.1",
     "chai-things": "^0.2.0",
-    "coveralls": "^2.11.16",
+    "coveralls": "^3.0.3",
     "eslint": "^4.6.1",
     "eslint-config-airbnb-base": "^12.0.0",
     "eslint-plugin-import": "^2.0.1",
-    "mocha": "^3.5.3",
+    "mocha": "^3.5.2",
     "nyc": "^11.2.1",
-    "sinon": "^3.2.1"
+    "sinon": "^7.2.7"
   }
 }

--- a/test/Bucket.spec.js
+++ b/test/Bucket.spec.js
@@ -7,7 +7,9 @@ describe('Bucket Class', () => {
   let bucket;
 
   beforeEach(() => {
-    bucket = new Bucket();
+    bucket = new Bucket({
+      countTotal: 0, countTotalDeriv: 0, countSuccess: 0, countSuccessDeriv: 0, countFailure: 0, countFailureDeriv: 0, countTimeout: 0, countTimeoutDeriv: 0, countShortCircuited: 0, countShortCircuitedDeriv: 0
+    });
   });
 
   it('Should be instantied with all empty values', () => {

--- a/test/Stats.spec.js
+++ b/test/Stats.spec.js
@@ -113,14 +113,24 @@ describe('Stats Class', () => {
         0.95: 0,
         0.99: 0,
         0.995: 0
-      }
+      },
+      countFailure: 0,
+      countFailureDeriv: 0,
+      countShortCircuited: 0,
+      countShortCircuitedDeriv: 0,
+      countSuccess: 0,
+      countSuccessDeriv: 0,
+      countTimeout: 0,
+      countTimeoutDeriv: 0,
+      countTotal: 0,
+      countTotalDeriv: 0,
     });
   });
   it('Generate Complete Stats', () => {
     const stats = new Stats();
     const buckets = [
-      new Bucket(),
-      new Bucket()
+      new Bucket(stats.getCummulateiveSatistics()),
+      new Bucket(stats.getCummulateiveSatistics())
     ];
     buckets[0].failure(145);
     buckets[1].failure(234);
@@ -145,7 +155,17 @@ describe('Stats Class', () => {
         0.95: 1234,
         0.99: 1234,
         0.995: 1234
-      }
+      },
+      countFailure: 2,
+      countFailureDeriv: 2,
+      countShortCircuited: 0,
+      countShortCircuitedDeriv: 0,
+      countSuccess: 2,
+      countSuccessDeriv: 2,
+      countTimeout: 2,
+      countTimeoutDeriv: 2,
+      countTotal: 6,
+      countTotalDeriv: 6,
     });
     expect(stats._totals).to.deep.equal({
       total: 6,
@@ -164,7 +184,17 @@ describe('Stats Class', () => {
         0.95: 1234,
         0.99: 1234,
         0.995: 1234
-      }
+      },
+      countFailure: 2,
+      countFailureDeriv: 2,
+      countShortCircuited: 0,
+      countShortCircuitedDeriv: 0,
+      countSuccess: 2,
+      countSuccessDeriv: 2,
+      countTimeout: 2,
+      countTimeoutDeriv: 2,
+      countTotal: 6,
+      countTotalDeriv: 6,
     });
   });
   it('_update should emit an event', () => {
@@ -190,7 +220,17 @@ describe('Stats Class', () => {
         0.95: 0,
         0.99: 0,
         0.995: 0
-      }
+      },
+      countFailure: 0,
+      countFailureDeriv: 0,
+      countShortCircuited: 0,
+      countShortCircuitedDeriv: 0,
+      countSuccess: 0,
+      countSuccessDeriv: 0,
+      countTimeout: 0,
+      countTimeoutDeriv: 0,
+      countTotal: 0,
+      countTotalDeriv: 0,
     });
   });
   it('Should increment failure and call update', () => {
@@ -216,7 +256,17 @@ describe('Stats Class', () => {
         0.95: 0,
         0.99: 0,
         0.995: 0
-      }
+      },
+      countFailure: 1,
+      countFailureDeriv: 1,
+      countShortCircuited: 0,
+      countShortCircuitedDeriv: 0,
+      countSuccess: 0,
+      countSuccessDeriv: 0,
+      countTimeout: 0,
+      countTimeoutDeriv: 0,
+      countTotal: 1,
+      countTotalDeriv: 1,
     });
   });
   it('Should increment shortCircuit', () => {
@@ -242,7 +292,17 @@ describe('Stats Class', () => {
         0.95: 0,
         0.99: 0,
         0.995: 0
-      }
+      },
+      countFailure: 0,
+      countFailureDeriv: 0,
+      countShortCircuited: 1,
+      countShortCircuitedDeriv: 1,
+      countSuccess: 0,
+      countSuccessDeriv: 0,
+      countTimeout: 0,
+      countTimeoutDeriv: 0,
+      countTotal: 0,
+      countTotalDeriv: 0,
     });
   });
   it('Should increment success and call update', () => {
@@ -268,7 +328,17 @@ describe('Stats Class', () => {
         0.95: 0,
         0.99: 0,
         0.995: 0
-      }
+      },
+      countFailure: 0,
+      countFailureDeriv: 0,
+      countShortCircuited: 0,
+      countShortCircuitedDeriv: 0,
+      countSuccess: 1,
+      countSuccessDeriv: 1,
+      countTimeout: 0,
+      countTimeoutDeriv: 0,
+      countTotal: 1,
+      countTotalDeriv: 1,
     });
   });
   it('Should increment timedOut and call update', () => {
@@ -294,7 +364,17 @@ describe('Stats Class', () => {
         0.95: 0,
         0.99: 0,
         0.995: 0
-      }
+      },
+      countFailure: 0,
+      countFailureDeriv: 0,
+      countShortCircuited: 0,
+      countShortCircuitedDeriv: 0,
+      countSuccess: 0,
+      countSuccessDeriv: 0,
+      countTimeout: 1,
+      countTimeoutDeriv: 1,
+      countTotal: 1,
+      countTotalDeriv: 1,
     });
   });
   it('_snapshot should trigger event', () => {
@@ -321,7 +401,17 @@ describe('Stats Class', () => {
         0.95: 100,
         0.99: 100,
         0.995: 100
-      }
+      },
+      countFailure: 0,
+      countFailureDeriv: 0,
+      countShortCircuited: 0,
+      countShortCircuitedDeriv: 0,
+      countSuccess: 0,
+      countSuccessDeriv: 0,
+      countTimeout: 1,
+      countTimeoutDeriv: 1,
+      countTotal: 1,
+      countTotalDeriv: 1,
     });
   });
   it('_shiftAndPush should shift and push', () => {
@@ -354,7 +444,17 @@ describe('Stats Class', () => {
         0.95: 0,
         0.99: 0,
         0.995: 0
-      }
+      },
+      countFailure: 0,
+      countFailureDeriv: 0,
+      countShortCircuited: 0,
+      countShortCircuitedDeriv: 0,
+      countSuccess: 0,
+      countSuccessDeriv: 0,
+      countTimeout: 1,
+      countTimeoutDeriv: 1,
+      countTotal: 1,
+      countTotalDeriv: 1,
     });
   });
 });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -97,7 +97,17 @@ describe('utils', () => {
             0.95: 102,
             0.99: 103,
             0.995: 103
-          }
+          },
+          countFailure: 0,
+          countFailureDeriv: 0,
+          countShortCircuited: 0,
+          countShortCircuitedDeriv: 0,
+          countSuccess: 0,
+          countSuccessDeriv: 0,
+          countTimeout: 0,
+          countTimeoutDeriv: 0,
+          countTotal: 0,
+          countTotalDeriv: 0,
         }
       };
       const stats = statsOutput.stats;
@@ -163,7 +173,19 @@ describe('utils', () => {
         propertyValue_metricsRollingStatisticalWindowInMilliseconds: 10000, // todo
         propertyValue_requestCacheEnabled: false, // not reported
         propertyValue_requestLogEnabled: false, // not reported
-        reportingHosts: 1 // not reported
+        reportingHosts: 1, // not reported
+
+        countTotal: 0,
+        countSuccess: 0,
+        countFailure: 0,
+        countTimeout: 0,
+        countShortCircuited: 0,
+
+        countTotalDeriv: 0,
+        countSuccessDeriv: 0,
+        countFailureDeriv: 0,
+        countTimeoutDeriv: 0,
+        countShortCircuitedDeriv: 0,
       });
     });
   });


### PR DESCRIPTION
As proposed in https://github.com/awolden/brakes/issues/55 I added cumulative counters that are independent of buckets. These counter stream out total requests (timeouts, etc.) per breaker, as well as the diff between two report events. The latter is necessary to support Prometheus counters effectively.

Counters are supported and named aligned with the Hystrix Metrics and Monitoring guide: https://github.com/Netflix/Hystrix/wiki/Metrics-and-Monitoring