### PR TITLE
#105 added a toggle to disabled prefixing error message with circuit name

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ isOpen|N/A|boolean|Returns `true` if circuit is open
 - **fallback**: function to call for fallback (can be defined also with calling `fallback` function)
 - **isPromise**: `boolean` to opt out of check for callback in function. This affects the passed in function, health check and fallback
 - **isFunction**: `boolean` to opt out of check for callback, always promisifying in function. This affects the passed in function, health check and fallback
+- **modifyError**: modifies the error message by adding circuit name. default is true.
 
 ## Stats
 Based on the `opts.statInterval` an event will be fired at regular intervals that contains a snapshot of the running state of the application.

--- a/lib/Brakes.js
+++ b/lib/Brakes.js
@@ -23,7 +23,8 @@ const defaultOptions = {
   healthCheck: undefined,
   fallback: undefined,
   isFunction: false,
-  isPromise: false
+  isPromise: false,
+  modifyError: true
 };
 
 class Brakes extends EventEmitter {

--- a/lib/Circuit.js
+++ b/lib/Circuit.js
@@ -93,7 +93,7 @@ class Circuit extends EventEmitter {
           return this._brakes._fallback.apply(this, arguments);
         }
 
-        if (err.message && this._brakes.name) {
+        if (err.message && this._brakes.name && this._brakes._opts.modifyError) {
           err.message = `[Breaker: ${this._brakes.name}] ${err.message}`;
         }
 

--- a/test/Brakes.spec.js
+++ b/test/Brakes.spec.js
@@ -27,7 +27,12 @@ const defaultOptions = {
   healthCheck: undefined,
   fallback: undefined,
   isFunction: false,
-  isPromise: false
+  isPromise: false,
+  modifyError: true
+};
+
+const modifyError = function modifyError() {
+  throw new Error('Not found');
 };
 
 const noop = function noop(foo, err, cb) {
@@ -113,6 +118,14 @@ describe('Brakes Class', () => {
       expect(err.message).to.equal('[Breaker: defaultBrake] err');
     });
   });
+  it('Should not prefix error messages', () => {
+    brake = new Brakes(modifyError, {
+      modifyError: false,
+    });
+    return brake.exec(null).then(null, err => {
+      expect(err.message).to.equal('Not found');
+    });
+  });
 
   it('Should accept a promise', () => {
     brake = new Brakes(nopr);
@@ -163,7 +176,8 @@ describe('Brakes Class', () => {
       healthCheck: () => Promise.resolve(),
       fallback: () => Promise.resolve(),
       isFunction: false,
-      isPromise: false
+      isPromise: false,
+      modifyError: true
     };
     brake = new Brakes(noop, overrides);
     expect(brake._opts).to.deep.equal(overrides);


### PR DESCRIPTION
I've reproduced the changes and fixed the errors that are reported by Travis in #106 