### PR TITLE
Fix: Deal with exception when err is undefined.

### DIFF
--- a/lib/Circuit.js
+++ b/lib/Circuit.js
@@ -93,7 +93,7 @@ class Circuit extends EventEmitter {
           return this._brakes._fallback.apply(this, arguments);
         }
 
-        if (err.message && this._brakes.name && this._brakes._opts.modifyError) {
+        if (err && err.message && this._brakes.name && this._brakes._opts.modifyError) {
           err.message = `[Breaker: ${this._brakes.name}] ${err.message}`;
         }
 


### PR DESCRIPTION
Exception raised when running example1.js

```
Failure TypeError: Cannot read property 'message' of undefined
    at C:\code\brakes\lib\Circuit.js:96:17
    at tryCatcher (C:\code\brakes\node_modules\bluebird\js\release\util.js:16:23)
    at Promise._settlePromiseFromHandler (C:\code\brakes\node_modules\bluebird\js\release\promise.js:547:31)
    at Promise._settlePromise (C:\code\brakes\node_modules\bluebird\js\release\promise.js:604:18)
    at Promise._settlePromise0 (C:\code\brakes\node_modules\bluebird\js\release\promise.js:649:10)
    at Promise._settlePromises (C:\code\brakes\node_modules\bluebird\js\release\promise.js:725:18)
    at _drainQueueStep (C:\code\brakes\node_modules\bluebird\js\release\async.js:93:12)
    at _drainQueue (C:\code\brakes\node_modules\bluebird\js\release\async.js:86:9)
    at Async._drainQueues (C:\code\brakes\node_modules\bluebird\js\release\async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (C:\code\brakes\node_modules\bluebird\js\release\async.js:15:14)
    at processImmediate (internal/timers.js:439:21)
```