### PR TITLE
Fix the issue rawStream is paused in newer versions of Node

### DIFF
--- a/lib/globalStats.js
+++ b/lib/globalStats.js
@@ -21,7 +21,7 @@ class GlobalStats {
       objectMode: true,
       highWaterMark: 0
     });
-    this._hystrixStream._transform = this._transformToHysterix;
+    this._hystrixStream._transform = this._transformToHysterix.bind(this);
     this._hystrixStream.resume();
 
     // connect the streams
@@ -67,6 +67,9 @@ class GlobalStats {
     }
     catch (err) {
       return callback(err);
+    }
+    finally {
+      this._rawStream.resume();
     }
     return callback(null, `data: ${JSON.stringify(mappedStats)}\n\n`);
   }


### PR DESCRIPTION
This fixes the issue rawStream get paused and cannot pass check in https://github.com/awolden/brakes/blob/main/lib/globalStats.js#L54 after processing the first snapshot in the newer versions of Node. It is the issue mentioned in #120.