### PR TITLE
Add readableFlowing check to globalStream

### DIFF
--- a/lib/globalStats.js
+++ b/lib/globalStats.js
@@ -51,7 +51,9 @@ class GlobalStats {
   /* listen to event and pipe to stream */
   _globalListener(stats) {
     if (!stats || typeof stats !== 'object') return;
-    if (!this._rawStream.isPaused()) {
+
+    // as of node 12.6 we need to check for readableFlowing as well since the behavior of isPaused() has changed
+    if (!this._rawStream.isPaused() || this._rawStream.readableFlowing) {
       this._rawStream.push(JSON.stringify(stats));
     }
   }


### PR DESCRIPTION
Add readableFlowing check to fix issue with stream not flowing in versions of node > 12.

See: 
https://github.com/awolden/brakes/issues/120
https://github.com/awolden/brakes/pull/121